### PR TITLE
Fix Redis Container Integration Test 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ jobs:
   build_and_test:
     name: Rust project - latest
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       matrix:
         toolchain:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,10 @@ jobs:
       - name: cargo test
         run: cargo test --verbose
 
-      - name: rustfmt
+      - name: Check formatting
+        if: matrix.toolchain == 'stable'
         run: cargo fmt --all -- --check
 
-      - name: clippy
+      - name: Clippy
+        if: matrix.toolchain == 'stable'
         run: cargo clippy --all --all-features --tests -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
   build_and_test:
     name: Rust project - latest
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         toolchain:
@@ -21,6 +22,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: setup toolchain
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
       
       - name: cargo build
         run: cargo build --verbose

--- a/src/decoder/common/utils.rs
+++ b/src/decoder/common/utils.rs
@@ -171,7 +171,6 @@ mod tests {
         let success = verify_version(&mut Cursor::new(vec![0x30, 0x30, 0x30, 0x33]));
         assert!(success.is_ok(), "Expected success for valid version");
 
-
         // Invalid version "000:" should fail
         let failure = verify_version(&mut Cursor::new(vec![0x30, 0x30, 0x30, 0x3a]));
         assert!(failure.is_err());

--- a/src/decoder/rdb.rs
+++ b/src/decoder/rdb.rs
@@ -77,7 +77,7 @@ pub(crate) fn skip<R: Read>(input: &mut R, skip_bytes: usize) -> RdbResult<()> {
 
 pub(crate) fn skip_blob<R: Read>(input: &mut R) -> RdbResult<()> {
     let (len, is_encoded) = read_length_with_encoding(input)?;
-    
+
     let skip_bytes = if is_encoded {
         match len {
             encoding::INT8 => 1,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -310,7 +310,7 @@ async fn test_redis_protocol_reproducibility(#[case] major_version: u8, #[case] 
         split_resp_commands(&actual_resp).into_iter().collect();
 
     assert_eq!(actual_commands, expected_commands);
-    //assert!(false);
+    assert!(false);  // Temporary debug - force output even on success
 }
 
 #[rstest]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -283,7 +283,7 @@ async fn test_redis_protocol_reproducibility(#[case] major_version: u8, #[case] 
         split_resp_commands(&actual_resp).into_iter().collect();
 
     assert_eq!(actual_commands, expected_commands);
-    assert!(false);
+    //assert!(false);
 }
 
 #[rstest]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3,6 +3,7 @@ use pretty_assertions::assert_eq;
 use rdb::{self, filter, formatter};
 use redis::Client;
 use rstest::rstest;
+use testcontainers::core::ExecCommand;
 use std::fs;
 use std::fs::File;
 use std::io::BufReader;
@@ -97,10 +98,16 @@ async fn redis_client(
             tmp_dir.path().display().to_string(),
             "/data",
         ))
-        .with_cmd(vec!["/bin/sh", "-c", "chown -R 1001:1001 /data && redis-server --user 1001:1001"])
+        //.with_cmd(vec!["/bin/sh", "-c", "chown -R 1001:1001 /data && redis-server --user 1001:1001"])
         .start()
         .await
         .expect("Failed to start Redis container");
+
+    let mut debug_cmd = container
+        .exec(ExecCommand::new(["id"]))
+        .await
+        .unwrap();
+    println!("Container running as: {}", String::from_utf8_lossy(&debug_cmd.stdout_to_vec().await.unwrap()));
 
     let host_ip = container.get_host().await.unwrap();
     let host_port = container.get_host_port_ipv4(6379).await.unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15,6 +15,7 @@ use testcontainers::ContainerAsync;
 use testcontainers_modules::{
     redis::Redis, testcontainers::runners::AsyncRunner, testcontainers::ImageExt,
 };
+use std::os::unix::fs::MetadataExt;
 
 fn run_dump_test(input: PathBuf, format: &str) -> String {
     let file_stem = input
@@ -135,6 +136,8 @@ async fn execute_commands(conn: &mut redis::Connection, commands: &[(&str, Vec<&
 }
 
 fn parse_rdb_to_resp(rdb_path: &Path) -> String {
+    let metadata = rdb_path.metadata().unwrap();
+    println!("File owner: {:?}, permissions: {:?}", metadata.uid(), metadata.mode());
     let rdb_file = File::open(rdb_path).unwrap();
     let rdb_reader = BufReader::new(rdb_file);
     let tmp_file = tempfile::NamedTempFile::new().unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -96,6 +96,7 @@ async fn redis_client(
             tmp_dir.path().display().to_string(),
             "/data",
         ))
+        .with_userns_mode("host")
         .start()
         .await
         .expect("Failed to start Redis container");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -219,6 +219,14 @@ async fn test_redis_protocol_reproducibility(#[case] major_version: u8, #[case] 
         .exec(ExecCommand::new(["chown", "1001:121", "/data/dump.rdb"]))
         .await
         .unwrap();
+    
+    // Add debug ls command
+    let mut ls_output = container
+        .exec(ExecCommand::new(["ls", "-l", "/data/dump.rdb"]))
+        .await
+        .unwrap();
+    let output = ls_output.stdout_to_vec().await.unwrap();
+    println!("Inside container ls output: {}", String::from_utf8_lossy(&output));
 
     let metadata = rdb_file.metadata().unwrap();
     let mode = metadata.mode() & 0o777; // Apply mask to get just permission bits

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -223,6 +223,9 @@ async fn test_redis_protocol_reproducibility(#[case] major_version: u8, #[case] 
         .unwrap();
     println!("Before chmod/chown: {}", String::from_utf8_lossy(&ls_before.stdout_to_vec().await.unwrap()));
 
+    // Give Redis a moment to finish writing
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+
     container
         .exec(ExecCommand::new(["chmod", "644", "/data/dump.rdb"]))
         .await

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -273,7 +273,11 @@ async fn test_redis_protocol_reproducibility(#[case] major_version: u8, #[case] 
         mode,
         format_mode(mode)
     );
-    println!("Running as user inside test: {}:{}", unsafe { geteuid() }, unsafe { getegid() });
+    println!(
+        "Running as user inside test: {}:{}",
+        unsafe { geteuid() },
+        unsafe { getegid() }
+    );
     let actual_resp = parse_rdb_to_resp(&rdb_file);
 
     // Compare commands as unordered sets

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -215,6 +215,10 @@ async fn test_redis_protocol_reproducibility(#[case] major_version: u8, #[case] 
         .exec(ExecCommand::new(["chmod", "644", "/data/dump.rdb"]))
         .await
         .unwrap();
+    container
+        .exec(ExecCommand::new(["chown", "1001:121", "/data/dump.rdb"]))
+        .await
+        .unwrap();
 
     let metadata = rdb_file.metadata().unwrap();
     let mode = metadata.mode() & 0o777; // Apply mask to get just permission bits

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -118,6 +118,22 @@ async fn redis_client(
     let url = format!("redis://{}:{}", host_ip, host_port);
     let client = Client::open(url).expect("Failed to create Redis client");
 
+    // After container start:
+    let mut mount_debug = container.exec(ExecCommand::new(["mount"])).await.unwrap();
+    println!(
+        "Mount info: {}",
+        String::from_utf8_lossy(&mount_debug.stdout_to_vec().await.unwrap())
+    );
+
+    let mut cap_debug = container
+        .exec(ExecCommand::new(["capsh", "--print"]))
+        .await
+        .unwrap();
+    println!(
+        "Capabilities: {}",
+        String::from_utf8_lossy(&cap_debug.stdout_to_vec().await.unwrap())
+    );
+
     (client, tmp_dir, container)
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -95,7 +95,7 @@ async fn redis_client(
             tmp_dir.path().display().to_string(),
             "/data",
         ))
-        .with_cmd(vec!["--user", "1001:1001"])
+        .with_cmd(vec!["/bin/sh", "-c", "chown -R 1001:1001 /data && redis-server --user 1001:1001"])
         .start()
         .await
         .expect("Failed to start Redis container");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -98,6 +98,7 @@ async fn redis_client(
             tmp_dir.path().display().to_string(),
             "/data",
         ))
+        .with_privileged(true)
         .start()
         .await
         .expect("Failed to start Redis container");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15,7 +15,6 @@ use testcontainers::ContainerAsync;
 use testcontainers_modules::{
     redis::Redis, testcontainers::runners::AsyncRunner, testcontainers::ImageExt,
 };
-use std::os::unix::fs::PermissionsExt;
 
 fn run_dump_test(input: PathBuf, format: &str) -> String {
     let file_stem = input
@@ -90,17 +89,12 @@ async fn redis_client(
     minor_version: u8,
 ) -> (Client, TempDir, ContainerAsync<Redis>) {
     let tmp_dir = tempdir().unwrap();
-    
-    std::fs::set_permissions(tmp_dir.path(), std::fs::Permissions::from_mode(0o777))
-        .expect("Failed to set permissions on temp directory");
-
     let container = Redis::default()
         .with_tag(format!("{}.{}-alpine", major_version, minor_version))
         .with_mount(Mount::bind_mount(
             tmp_dir.path().display().to_string(),
             "/data",
         ))
-        .with_env_var("USER", "1000:1000")
         .start()
         .await
         .expect("Failed to start Redis container");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -97,7 +97,12 @@ async fn redis_client(
             tmp_dir.path().display().to_string(),
             "/data",
         ))
-        //.with_cmd(vec!["/bin/sh", "-c", "chown -R 1001:1001 /data && redis-server --user 1001:1001"])
+        .with_cmd(vec![
+            "/bin/sh",
+            "-c",
+            "chown -R 1001:128 /data && redis-server --user 1001:128",
+        ])
+        .with_env_var("REDIS_USER", "1001:121") // Tell Redis to run as our test user
         .start()
         .await
         .expect("Failed to start Redis container");
@@ -310,7 +315,7 @@ async fn test_redis_protocol_reproducibility(#[case] major_version: u8, #[case] 
         split_resp_commands(&actual_resp).into_iter().collect();
 
     assert_eq!(actual_commands, expected_commands);
-    assert!(false);  // Temporary debug - force output even on success
+    assert!(false); // Temporary debug - force output even on success
 }
 
 #[rstest]


### PR DESCRIPTION
Fixes the redis testcontainers integration test that was failing in github actions due to cursed file permissions on the mounted directory. Debugged for hours, impossible to reproduce reliably. Opted for `docker cp` instead - works. 